### PR TITLE
Fix security rule for user endpoint

### DIFF
--- a/backend/src/main/java/com/securefileshare/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/securefileshare/backend/config/SecurityConfig.java
@@ -6,6 +6,7 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.http.HttpMethod;
 
 @Configuration
 public class SecurityConfig {
@@ -15,7 +16,8 @@ public class SecurityConfig {
         return http
             .csrf(csrf -> csrf.disable()) // Disable CSRF for Postman testing
             .authorizeHttpRequests(auth -> auth
-                .requestMatchers("/api/users", "/api/auth/login").permitAll()
+                .requestMatchers(HttpMethod.POST, "/api/users").permitAll()
+                .requestMatchers("/api/auth/login").permitAll()
                 .anyRequest().authenticated()
             )
             .build();


### PR DESCRIPTION
## Summary
- ensure only user registration is public

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844d41c8d408322b46ae319fc14507b