### PR TITLE
Add custom user details service

### DIFF
--- a/backend/src/main/java/com/securefileshare/backend/config/SecurityConfig.java
+++ b/backend/src/main/java/com/securefileshare/backend/config/SecurityConfig.java
@@ -4,6 +4,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import com.securefileshare.backend.service.CustomUserDetailsService;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.http.HttpMethod;
@@ -12,7 +13,7 @@ import org.springframework.http.HttpMethod;
 public class SecurityConfig {
 
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+    public SecurityFilterChain filterChain(HttpSecurity http, CustomUserDetailsService userDetailsService) throws Exception {
         return http
             .csrf(csrf -> csrf.disable()) // Disable CSRF for Postman testing
             .authorizeHttpRequests(auth -> auth
@@ -20,6 +21,7 @@ public class SecurityConfig {
                 .requestMatchers("/api/auth/login").permitAll()
                 .anyRequest().authenticated()
             )
+            .userDetailsService(userDetailsService)
             .build();
     }
 

--- a/backend/src/main/java/com/securefileshare/backend/repository/UserRepository.java
+++ b/backend/src/main/java/com/securefileshare/backend/repository/UserRepository.java
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByUsername(String username);
+    java.util.Optional<User> findByUsername(String username);
 }

--- a/backend/src/main/java/com/securefileshare/backend/service/CustomUserDetailsService.java
+++ b/backend/src/main/java/com/securefileshare/backend/service/CustomUserDetailsService.java
@@ -1,0 +1,38 @@
+package com.securefileshare.backend.service;
+
+import com.securefileshare.backend.model.User;
+import com.securefileshare.backend.repository.UserRepository;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    public CustomUserDetailsService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found"));
+
+        return org.springframework.security.core.userdetails.User
+                .withUsername(user.getUsername())
+                .password(user.getPassword())
+                .roles("USER")
+                .build();
+    }
+}


### PR DESCRIPTION
## Summary
- add `findByUsername` method in `UserRepository`
- add `CustomUserDetailsService` implementing `UserDetailsService`
- inject the service in `SecurityConfig`

## Testing
- `mvn test` *(fails: mvn not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685b2e3402bc8322b6b3cb2ebedc9a51